### PR TITLE
Added "OpenLineDiagnostic"

### DIFF
--- a/plugin/diagnostic.vim
+++ b/plugin/diagnostic.vim
@@ -8,6 +8,7 @@ command! PrevDiagnosticCycle lua require'jumpLoc'.jumpPrevLocationCycle()
 command! NextDiagnostic lua require'jumpLoc'.jumpNextLocation()
 command! NextDiagnosticCycle lua require'jumpLoc'.jumpNextLocationCycle()
 command! OpenDiagnostic lua require'jumpLoc'.openDiagnostics()
+command! OpenLineDiagnostic lua require'jumpLoc'.openLineDiagnostics()
 
 " lua require'diagnostic'.modifyCallback()
 


### PR DESCRIPTION
this command can be bound to a key now, so that the diagnostic popup may be opened on keypress when you're on the same line.
```
nnoremap <silent> gh    <cmd>OpenLineDiagnostic<CR>
```
closes #14