### PR TITLE
Add diagnostic_enable_location_list to enable/disable loclist

### DIFF
--- a/lua/diagnostic.lua
+++ b/lua/diagnostic.lua
@@ -65,7 +65,10 @@ function M.diagnostics_loclist(local_result)
       v.uri = v.uri or local_result.uri
     end
   end
-  vim.lsp.util.set_loclist(vim.lsp.util.locations_to_items(local_result.diagnostics))
+
+  if vim.api.nvim_get_var('diagnostic_enable_location_list') == 1 then
+      vim.lsp.util.set_loclist(vim.lsp.util.locations_to_items(local_result.diagnostics))
+  end
 end
 
 function M.publish_diagnostics(bufnr)

--- a/plugin/diagnostic.vim
+++ b/plugin/diagnostic.vim
@@ -49,6 +49,10 @@ if ! exists('g:diagnostic_level')
     let g:diagnostic_level = 'Hint'
 endif
 
+if ! exists('g:diagnostic_enable_location_list')
+    let g:diagnostic_enable_location_list = 1
+endif
+
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
I use Neomake for linting as well and I found this option to be useful. But maybe instead of replacing the loclist, I can append to it. But I'm not sure how well that would work.

I think this is a useful addition, but let me know If it's not inline with how you see your plugin moving forward.