### PR TITLE
Remove spam from diagnostic

### DIFF
--- a/lua/diagnostic.lua
+++ b/lua/diagnostic.lua
@@ -44,6 +44,9 @@ function M.modifyCallback()
       vim.lsp.err_message("LSP.publishDiagnostics: Couldn't find buffer for ", uri)
       return
     end
+    if not vim.api.nvim_buf_is_loaded(bufnr) then
+      return
+    end
     get_diagnostics_count(result.diagnostics, bufnr)
     if vim.api.nvim_get_var('diagnostic_level') ~= nil then
       result.diagnostics = remove_diagnostics(result.diagnostics)


### PR DESCRIPTION
As stated in the original implementation of the callback, we should
check if the buffer is loaded to avoid spamming.

More info here: https://github.com/neovim/neovim/blob/569e75799d7015b15631c80cee1feec561f29df7/runtime/lua/vim/lsp/callbacks.lua#L85-L93